### PR TITLE
fix: Remove duplicate status notifications during translation in SelectElement

### DIFF
--- a/content.js
+++ b/content.js
@@ -154,15 +154,12 @@ class TranslationHandler {
       return;
     }
 
-    const statusNotification = this.notifier.show("در حال ترجمه...", "status");
-
     try {
       // Process each text node separately
       await this.translateTextNodesInElement(state.highlightedElement);
     } catch (error) {
       this.handleError(error);
     } finally {
-      this.notifier.dismiss(statusNotification);
       this.elementManager.cleanup();
     }
   }


### PR DESCRIPTION
This pull request addresses an issue where duplicate status notifications were displayed during the translation process in the `SelectElement` component.